### PR TITLE
chore(deps): update concerto to 3.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "3.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "3.8.1",
+        "@accordproject/concerto-analysis": "3.11.0",
         "@accordproject/concerto-codegen": "3.15.0",
-        "@accordproject/concerto-core": "3.8.1",
-        "@accordproject/concerto-cto": "3.8.1",
-        "@accordproject/concerto-metamodel": "3.8.0",
-        "@accordproject/concerto-util": "3.8.1",
+        "@accordproject/concerto-core": "3.11.0",
+        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.11.0",
         "ansi-colors": "4.1.3",
         "glob": "^7.2.0",
         "randexp": "^0.5.3",
@@ -43,12 +43,12 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.8.1.tgz",
-      "integrity": "sha512-6WNpsS/Oxm1inx8ZIoqrPvDv+6pX8w2m3UGHyRJt+NNgtupYzCItNxMnJsW15YmbxiDG0xmVahqhyR76WKuQzQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.0.tgz",
+      "integrity": "sha512-YIEFz72g1gWfW22w8EDRdlO3UbdFHQ/FYHQiiS7SGkWLp9QPsifOiH1y5chYGxspqeU3EgHPdc9uT4hjgVO8gQ==",
       "dependencies": {
-        "@accordproject/concerto-core": "3.8.1",
-        "semver": "7.3.5"
+        "@accordproject/concerto-core": "3.11.0",
+        "semver": "7.5.4"
       },
       "engines": {
         "node": ">=14",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -91,24 +91,7 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.0.tgz",
-      "integrity": "sha512-zSGjMjxGAyNkDWRMP7JYmNwZMQmlcfJDg/JuG/2+UsBCw9l7esp915s/fwM/m+v9R9HV7Fvj1d01NmrwKCvlqw==",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
-        "colors": "1.4.0",
-        "debug": "4.3.1",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-core": {
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.8.1.tgz",
       "integrity": "sha512-hIFHLAIue0l66+ATCWGRXUXOovjgGzNW3DL1ZSZa4EaUGIbqBL6dKSqCBSNo76p4tUzxc3FNjAaan7eZMV8xcQ==",
@@ -130,64 +113,7 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-cto": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.8.1.tgz",
-      "integrity": "sha512-Hooc1Aceuqhr9WARIUEfqKLGkjhttjLgWNYEpHlBunlc34zQ3DZP92qvBJe7KfwVzV60/ZrJynrnTikHRi+47g==",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.8.0",
-        "@accordproject/concerto-util": "3.8.1",
-        "path-browserify": "1.0.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
-      "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.7.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
-      "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
-        "colors": "1.4.0",
-        "debug": "4.3.1",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-util": {
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.1.tgz",
       "integrity": "sha512-H5HJ8E7GaB31cKHbmd1/z+sXmUIoCwuebHs52d5OJd6FXmgjUAdW/4F2papDJ72bDIpk6ua2pf4zBWTW93mH4Q==",
@@ -204,6 +130,193 @@
         "npm": ">=6"
       }
     },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-cto": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.8.1.tgz",
+      "integrity": "sha512-Hooc1Aceuqhr9WARIUEfqKLGkjhttjLgWNYEpHlBunlc34zQ3DZP92qvBJe7KfwVzV60/ZrJynrnTikHRi+47g==",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.8.0",
+        "@accordproject/concerto-util": "3.8.1",
+        "path-browserify": "1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-util": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.1.tgz",
+      "integrity": "sha512-H5HJ8E7GaB31cKHbmd1/z+sXmUIoCwuebHs52d5OJd6FXmgjUAdW/4F2papDJ72bDIpk6ua2pf4zBWTW93mH4Q==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
+      "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
+      "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.0.tgz",
+      "integrity": "sha512-zSGjMjxGAyNkDWRMP7JYmNwZMQmlcfJDg/JuG/2+UsBCw9l7esp915s/fwM/m+v9R9HV7Fvj1d01NmrwKCvlqw==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-codegen/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.0.tgz",
+      "integrity": "sha512-pogSrR0zzESFa5A57iTrwEtu6D8bEbG9NJLJW1UmxLjeHZ62V0Hn5GTrrSnVVxjaprlS2i0nPxj1w2vfm7H+/A==",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.11.0",
+        "dayjs": "1.10.8",
+        "debug": "4.3.1",
+        "lorem-ipsum": "2.0.3",
+        "randexp": "0.5.3",
+        "semver": "7.5.4",
+        "slash": "3.0.0",
+        "urijs": "1.19.11",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-cto": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.0.tgz",
+      "integrity": "sha512-tftcwDfjKxSJg70YcTGVkSzs2ao60uANeSLJm+cXLKPnWATJNtteLpGAsfM0Kwuz0ASGSkAqTtIFAlb67YoyqA==",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.11.0",
+        "path-browserify": "1.0.1"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
+      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.9.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
+      "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-util": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.0.tgz",
+      "integrity": "sha512-QKZgDXPDeq+9HILKT4y8J0KNic7/mtxXFTz0rTOhGZ5EgAOKKDgoyv746qKy07JjwOi7XWIcs1leWbdilhhQEg==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
     "node_modules/@accordproject/concerto-vocabulary": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-3.8.2.tgz",
@@ -211,6 +324,35 @@
       "dependencies": {
         "@accordproject/concerto-metamodel": "3.8.0",
         "yaml": "2.2.2"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
+      "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-util": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
+      "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
       },
       "engines": {
         "node": ">=14",
@@ -4309,18 +4451,18 @@
   },
   "dependencies": {
     "@accordproject/concerto-analysis": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.8.1.tgz",
-      "integrity": "sha512-6WNpsS/Oxm1inx8ZIoqrPvDv+6pX8w2m3UGHyRJt+NNgtupYzCItNxMnJsW15YmbxiDG0xmVahqhyR76WKuQzQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.0.tgz",
+      "integrity": "sha512-YIEFz72g1gWfW22w8EDRdlO3UbdFHQ/FYHQiiS7SGkWLp9QPsifOiH1y5chYGxspqeU3EgHPdc9uT4hjgVO8gQ==",
       "requires": {
-        "@accordproject/concerto-core": "3.8.1",
-        "semver": "7.3.5"
+        "@accordproject/concerto-core": "3.11.0",
+        "semver": "7.5.4"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4345,6 +4487,87 @@
         "pluralize": "8.0.0"
       },
       "dependencies": {
+        "@accordproject/concerto-core": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.8.1.tgz",
+          "integrity": "sha512-hIFHLAIue0l66+ATCWGRXUXOovjgGzNW3DL1ZSZa4EaUGIbqBL6dKSqCBSNo76p4tUzxc3FNjAaan7eZMV8xcQ==",
+          "requires": {
+            "@accordproject/concerto-cto": "3.8.1",
+            "@accordproject/concerto-metamodel": "3.8.0",
+            "@accordproject/concerto-util": "3.8.1",
+            "dayjs": "1.10.8",
+            "debug": "4.3.1",
+            "lorem-ipsum": "2.0.3",
+            "randexp": "0.5.3",
+            "semver": "7.3.5",
+            "slash": "3.0.0",
+            "urijs": "1.19.11",
+            "uuid": "8.3.2"
+          },
+          "dependencies": {
+            "@accordproject/concerto-util": {
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.1.tgz",
+              "integrity": "sha512-H5HJ8E7GaB31cKHbmd1/z+sXmUIoCwuebHs52d5OJd6FXmgjUAdW/4F2papDJ72bDIpk6ua2pf4zBWTW93mH4Q==",
+              "requires": {
+                "@supercharge/promise-pool": "1.7.0",
+                "axios": "0.23.0",
+                "colors": "1.4.0",
+                "debug": "4.3.1",
+                "json-colorizer": "2.2.2",
+                "slash": "3.0.0"
+              }
+            }
+          }
+        },
+        "@accordproject/concerto-cto": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.8.1.tgz",
+          "integrity": "sha512-Hooc1Aceuqhr9WARIUEfqKLGkjhttjLgWNYEpHlBunlc34zQ3DZP92qvBJe7KfwVzV60/ZrJynrnTikHRi+47g==",
+          "requires": {
+            "@accordproject/concerto-metamodel": "3.8.0",
+            "@accordproject/concerto-util": "3.8.1",
+            "path-browserify": "1.0.1"
+          },
+          "dependencies": {
+            "@accordproject/concerto-util": {
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.1.tgz",
+              "integrity": "sha512-H5HJ8E7GaB31cKHbmd1/z+sXmUIoCwuebHs52d5OJd6FXmgjUAdW/4F2papDJ72bDIpk6ua2pf4zBWTW93mH4Q==",
+              "requires": {
+                "@supercharge/promise-pool": "1.7.0",
+                "axios": "0.23.0",
+                "colors": "1.4.0",
+                "debug": "4.3.1",
+                "json-colorizer": "2.2.2",
+                "slash": "3.0.0"
+              }
+            }
+          }
+        },
+        "@accordproject/concerto-metamodel": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
+          "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
+          "requires": {
+            "@accordproject/concerto-util": "3.7.0"
+          },
+          "dependencies": {
+            "@accordproject/concerto-util": {
+              "version": "3.7.0",
+              "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
+              "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
+              "requires": {
+                "@supercharge/promise-pool": "1.7.0",
+                "axios": "0.23.0",
+                "colors": "1.4.0",
+                "debug": "4.3.1",
+                "json-colorizer": "2.2.2",
+                "slash": "3.0.0"
+              }
+            }
+          }
+        },
         "@accordproject/concerto-util": {
           "version": "3.8.0",
           "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.0.tgz",
@@ -4357,27 +4580,7 @@
             "json-colorizer": "2.2.2",
             "slash": "3.0.0"
           }
-        }
-      }
-    },
-    "@accordproject/concerto-core": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.8.1.tgz",
-      "integrity": "sha512-hIFHLAIue0l66+ATCWGRXUXOovjgGzNW3DL1ZSZa4EaUGIbqBL6dKSqCBSNo76p4tUzxc3FNjAaan7eZMV8xcQ==",
-      "requires": {
-        "@accordproject/concerto-cto": "3.8.1",
-        "@accordproject/concerto-metamodel": "3.8.0",
-        "@accordproject/concerto-util": "3.8.1",
-        "dayjs": "1.10.8",
-        "debug": "4.3.1",
-        "lorem-ipsum": "2.0.3",
-        "randexp": "0.5.3",
-        "semver": "7.3.5",
-        "slash": "3.0.0",
-        "urijs": "1.19.11",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -4388,28 +4591,56 @@
         }
       }
     },
-    "@accordproject/concerto-cto": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.8.1.tgz",
-      "integrity": "sha512-Hooc1Aceuqhr9WARIUEfqKLGkjhttjLgWNYEpHlBunlc34zQ3DZP92qvBJe7KfwVzV60/ZrJynrnTikHRi+47g==",
+    "@accordproject/concerto-core": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.0.tgz",
+      "integrity": "sha512-pogSrR0zzESFa5A57iTrwEtu6D8bEbG9NJLJW1UmxLjeHZ62V0Hn5GTrrSnVVxjaprlS2i0nPxj1w2vfm7H+/A==",
       "requires": {
-        "@accordproject/concerto-metamodel": "3.8.0",
-        "@accordproject/concerto-util": "3.8.1",
+        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.11.0",
+        "dayjs": "1.10.8",
+        "debug": "4.3.1",
+        "lorem-ipsum": "2.0.3",
+        "randexp": "0.5.3",
+        "semver": "7.5.4",
+        "slash": "3.0.0",
+        "urijs": "1.19.11",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@accordproject/concerto-cto": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.0.tgz",
+      "integrity": "sha512-tftcwDfjKxSJg70YcTGVkSzs2ao60uANeSLJm+cXLKPnWATJNtteLpGAsfM0Kwuz0ASGSkAqTtIFAlb67YoyqA==",
+      "requires": {
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.11.0",
         "path-browserify": "1.0.1"
       }
     },
     "@accordproject/concerto-metamodel": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
-      "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
+      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
       "requires": {
-        "@accordproject/concerto-util": "3.7.0"
+        "@accordproject/concerto-util": "3.9.1"
       },
       "dependencies": {
         "@accordproject/concerto-util": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
-          "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
+          "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
           "requires": {
             "@supercharge/promise-pool": "1.7.0",
             "axios": "0.23.0",
@@ -4422,9 +4653,9 @@
       }
     },
     "@accordproject/concerto-util": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.8.1.tgz",
-      "integrity": "sha512-H5HJ8E7GaB31cKHbmd1/z+sXmUIoCwuebHs52d5OJd6FXmgjUAdW/4F2papDJ72bDIpk6ua2pf4zBWTW93mH4Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.0.tgz",
+      "integrity": "sha512-QKZgDXPDeq+9HILKT4y8J0KNic7/mtxXFTz0rTOhGZ5EgAOKKDgoyv746qKy07JjwOi7XWIcs1leWbdilhhQEg==",
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
         "axios": "0.23.0",
@@ -4441,6 +4672,29 @@
       "requires": {
         "@accordproject/concerto-metamodel": "3.8.0",
         "yaml": "2.2.2"
+      },
+      "dependencies": {
+        "@accordproject/concerto-metamodel": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.0.tgz",
+          "integrity": "sha512-oqJP+6xKlnvR4SrDU3U+iMhFeErdn9uKRdMqlOj6lW5Geyi4DTTURkf1Vf+x8LeI6CwuOErSNNxVVKFd3LoVjQ==",
+          "requires": {
+            "@accordproject/concerto-util": "3.7.0"
+          }
+        },
+        "@accordproject/concerto-util": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.7.0.tgz",
+          "integrity": "sha512-3qGVb/pv12hy5g44JvSH4ZZtFQ/9KNd9lWvVdh7AGfgtUdhPwlAssZTrmfY96uNP0eVE786HedC1DH6YstNK8g==",
+          "requires": {
+            "@supercharge/promise-pool": "1.7.0",
+            "axios": "0.23.0",
+            "colors": "1.4.0",
+            "debug": "4.3.1",
+            "json-colorizer": "2.2.2",
+            "slash": "3.0.0"
+          }
+        }
       }
     },
     "@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4306,9 +4306,9 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7669,9 +7669,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   "dependencies": {
     "@accordproject/concerto-analysis": "3.8.1",
     "@accordproject/concerto-codegen": "3.15.0",
-    "@accordproject/concerto-core": "3.8.1",
+    "@accordproject/concerto-core": "3.11.0",
     "@accordproject/concerto-cto": "3.8.1",
-    "@accordproject/concerto-metamodel": "3.8.0",
+    "@accordproject/concerto-metamodel": "3.8.1",
     "@accordproject/concerto-util": "3.8.1",
     "ansi-colors": "4.1.3",
     "glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "tmp-promise": "3.0.2"
   },
   "dependencies": {
-    "@accordproject/concerto-analysis": "3.8.1",
+    "@accordproject/concerto-analysis": "3.11.0",
     "@accordproject/concerto-codegen": "3.15.0",
     "@accordproject/concerto-core": "3.11.0",
-    "@accordproject/concerto-cto": "3.8.1",
+    "@accordproject/concerto-cto": "3.11.0",
     "@accordproject/concerto-metamodel": "3.8.1",
-    "@accordproject/concerto-util": "3.8.1",
+    "@accordproject/concerto-util": "3.11.0",
     "ansi-colors": "4.1.3",
     "glob": "^7.2.0",
     "randexp": "^0.5.3",


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
Updates Concerto package dependencies:

```
    "@accordproject/concerto-analysis": "3.11.0",
    "@accordproject/concerto-core": "3.11.0",
    "@accordproject/concerto-cto": "3.11.0",
    "@accordproject/concerto-metamodel": "3.8.1",
    "@accordproject/concerto-util": "3.11.0",
```
