### PR TITLE
chore(deps): update concerto to 3.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "3.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "3.11.0",
+        "@accordproject/concerto-analysis": "3.11.1-20230817140948",
         "@accordproject/concerto-codegen": "3.15.0",
-        "@accordproject/concerto-core": "3.11.0",
-        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-core": "3.11.1-20230817140948",
+        "@accordproject/concerto-cto": "3.11.1-20230817140948",
         "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.11.0",
+        "@accordproject/concerto-util": "3.11.1-20230817140948",
         "ansi-colors": "4.1.3",
         "glob": "^7.2.0",
         "randexp": "^0.5.3",
@@ -43,11 +43,11 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.0.tgz",
-      "integrity": "sha512-YIEFz72g1gWfW22w8EDRdlO3UbdFHQ/FYHQiiS7SGkWLp9QPsifOiH1y5chYGxspqeU3EgHPdc9uT4hjgVO8gQ==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-I9tgPeSRiKi6oPc6OtaBVZsxYFgFmiPfHc+bkVFubTsLORrM9UouKzK1Zk5UdnNJ+gEHJhdnJpa0RWPlPan0kA==",
       "dependencies": {
-        "@accordproject/concerto-core": "3.11.0",
+        "@accordproject/concerto-core": "3.11.1-20230817140948",
         "semver": "7.5.4"
       },
       "engines": {
@@ -222,13 +222,13 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.0.tgz",
-      "integrity": "sha512-pogSrR0zzESFa5A57iTrwEtu6D8bEbG9NJLJW1UmxLjeHZ62V0Hn5GTrrSnVVxjaprlS2i0nPxj1w2vfm7H+/A==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-1D8y7FuGROdv2zoMLdk4YxgAlYN9MQvuRYU6/81kwZdid3DsljhcDv585dnfpo15PlgFwl9/MeqHRXzLAma1Yw==",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-cto": "3.11.1-20230817140948",
         "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.11.0",
+        "@accordproject/concerto-util": "3.11.1-20230817140948",
         "dayjs": "1.10.8",
         "debug": "4.3.1",
         "lorem-ipsum": "2.0.3",
@@ -258,12 +258,12 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.0.tgz",
-      "integrity": "sha512-tftcwDfjKxSJg70YcTGVkSzs2ao60uANeSLJm+cXLKPnWATJNtteLpGAsfM0Kwuz0ASGSkAqTtIFAlb67YoyqA==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-2jS4/U7IsBw75AGXtubiaUAAnFfltnzYAYoC0oMa6Kbagdtx58DQNZH8PFJuy0eQAdGXJGqBlVY1n/zZ/xDwDQ==",
       "dependencies": {
         "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.11.0",
+        "@accordproject/concerto-util": "3.11.1-20230817140948",
         "path-browserify": "1.0.1"
       },
       "engines": {
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.0.tgz",
-      "integrity": "sha512-QKZgDXPDeq+9HILKT4y8J0KNic7/mtxXFTz0rTOhGZ5EgAOKKDgoyv746qKy07JjwOi7XWIcs1leWbdilhhQEg==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-A46DCx5HflRaxhVhiL5L+IvAnWzFn28/4/9Iek1yvoFUPPnVTGwD2a+YqGe1Ki7Fyb94CcVSMxOpFHTP4A6ewQ==",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
         "axios": "0.23.0",
@@ -4451,11 +4451,11 @@
   },
   "dependencies": {
     "@accordproject/concerto-analysis": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.0.tgz",
-      "integrity": "sha512-YIEFz72g1gWfW22w8EDRdlO3UbdFHQ/FYHQiiS7SGkWLp9QPsifOiH1y5chYGxspqeU3EgHPdc9uT4hjgVO8gQ==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-I9tgPeSRiKi6oPc6OtaBVZsxYFgFmiPfHc+bkVFubTsLORrM9UouKzK1Zk5UdnNJ+gEHJhdnJpa0RWPlPan0kA==",
       "requires": {
-        "@accordproject/concerto-core": "3.11.0",
+        "@accordproject/concerto-core": "3.11.1-20230817140948",
         "semver": "7.5.4"
       },
       "dependencies": {
@@ -4592,13 +4592,13 @@
       }
     },
     "@accordproject/concerto-core": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.0.tgz",
-      "integrity": "sha512-pogSrR0zzESFa5A57iTrwEtu6D8bEbG9NJLJW1UmxLjeHZ62V0Hn5GTrrSnVVxjaprlS2i0nPxj1w2vfm7H+/A==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-1D8y7FuGROdv2zoMLdk4YxgAlYN9MQvuRYU6/81kwZdid3DsljhcDv585dnfpo15PlgFwl9/MeqHRXzLAma1Yw==",
       "requires": {
-        "@accordproject/concerto-cto": "3.11.0",
+        "@accordproject/concerto-cto": "3.11.1-20230817140948",
         "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.11.0",
+        "@accordproject/concerto-util": "3.11.1-20230817140948",
         "dayjs": "1.10.8",
         "debug": "4.3.1",
         "lorem-ipsum": "2.0.3",
@@ -4620,12 +4620,12 @@
       }
     },
     "@accordproject/concerto-cto": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.0.tgz",
-      "integrity": "sha512-tftcwDfjKxSJg70YcTGVkSzs2ao60uANeSLJm+cXLKPnWATJNtteLpGAsfM0Kwuz0ASGSkAqTtIFAlb67YoyqA==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-2jS4/U7IsBw75AGXtubiaUAAnFfltnzYAYoC0oMa6Kbagdtx58DQNZH8PFJuy0eQAdGXJGqBlVY1n/zZ/xDwDQ==",
       "requires": {
         "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.11.0",
+        "@accordproject/concerto-util": "3.11.1-20230817140948",
         "path-browserify": "1.0.1"
       }
     },
@@ -4653,9 +4653,9 @@
       }
     },
     "@accordproject/concerto-util": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.0.tgz",
-      "integrity": "sha512-QKZgDXPDeq+9HILKT4y8J0KNic7/mtxXFTz0rTOhGZ5EgAOKKDgoyv746qKy07JjwOi7XWIcs1leWbdilhhQEg==",
+      "version": "3.11.1-20230817140948",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.11.1-20230817140948.tgz",
+      "integrity": "sha512-A46DCx5HflRaxhVhiL5L+IvAnWzFn28/4/9Iek1yvoFUPPnVTGwD2a+YqGe1Ki7Fyb94CcVSMxOpFHTP4A6ewQ==",
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
         "axios": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "tmp-promise": "3.0.2"
   },
   "dependencies": {
-    "@accordproject/concerto-analysis": "3.11.0",
+    "@accordproject/concerto-analysis": "3.11.1-20230817140948",
     "@accordproject/concerto-codegen": "3.15.0",
-    "@accordproject/concerto-core": "3.11.0",
-    "@accordproject/concerto-cto": "3.11.0",
+    "@accordproject/concerto-core": "3.11.1-20230817140948",
+    "@accordproject/concerto-cto": "3.11.1-20230817140948",
     "@accordproject/concerto-metamodel": "3.8.1",
-    "@accordproject/concerto-util": "3.11.0",
+    "@accordproject/concerto-util": "3.11.1-20230817140948",
     "ansi-colors": "4.1.3",
     "glob": "^7.2.0",
     "randexp": "^0.5.3",


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
Updates Concerto package dependencies:

```
    "@accordproject/concerto-analysis": "3.11.1",
    "@accordproject/concerto-core": "3.11.1",
    "@accordproject/concerto-cto": "3.11.1",
    "@accordproject/concerto-util": "3.11.1",
```
