### PR TITLE
feat(decorator): Added support for extracting decorators from model files

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,6 +477,7 @@ require('yargs')
         yargs.option('output', {
             describe: 'output directory path',
             type: 'string',
+            default: 'output'
         });
     }, argv => {
         const options = {

--- a/index.js
+++ b/index.js
@@ -456,6 +456,42 @@ require('yargs')
                 Logger.error(err.message);
             });
     })
+    .command('extract-decorators','extracts the decorator command sets and vocabularies from a list of model files', yargs =>{
+        yargs.demandOption('models','Please provide a model');
+        yargs.option('models', {
+            describe: 'The file location of the source models',
+            alias: 'model',
+            type: 'string',
+            array:true,
+        });
+        yargs.option('locale', {
+            describe: 'The locale for extracted vocabularies',
+            type: 'string',
+            default:'en'
+        });
+        yargs.option('removeDecoratorsFromSource', {
+            describe: 'Flag to determine whether to remove decorators from source model',
+            type: 'boolean',
+            default: false
+        });
+        yargs.option('output', {
+            describe: 'output directory path',
+            type: 'string',
+        });
+    }, argv => {
+        const options = {
+            locale: argv.locale,
+            removeDecoratorsFromModel: argv.removeDecoratorsFromSource,
+            output: argv.output
+        };
+        return Commands.extractDecorators(argv.models,options)
+            .then(result => {
+                Logger.info(result);
+            })
+            .catch((err) => {
+                Logger.error(err.message);
+            });
+    })
     .option('verbose', {
         alias: 'v',
         default: false

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -708,11 +708,9 @@ class Commands {
 
             const resp = DecoratorManager.extractDecorators(modelManager, options);
 
-            if (options.output) {
-                if (!fs.existsSync(options.output)) {
-                    // If it doesn't exist, create the directory
-                    fs.mkdirSync(options.output);
-                }
+            if (!fs.existsSync(options.output)) {
+                // If it doesn't exist, create the directory
+                fs.mkdirSync(options.output);
             }
 
             const namespaces = resp.modelManager.getNamespaces().filter(namespace=>namespace!=='concerto@1.0.0' && namespace!=='concerto');
@@ -722,29 +720,21 @@ class Commands {
                 let data =  Printer.toCTO(modelAst);
 
                 updatedModels.push(data);
-                if (options.output) {
-                    const filePath = path.join(options.output, model.namespace.split('@')[0]+'.cto');
-                    fs.writeFileSync(filePath, data);
-                }
+                const filePath = path.join(options.output, model.namespace.split('@')[0]+'.cto');
+                fs.writeFileSync(filePath, data);
             });
 
-            if (options.output) {
-                resp.decoratorCommandSet.forEach((dcs, index) => {
-                    const fileName = 'dcs_'+ index.toString();
-                    const filePath = path.join(options.output, fileName+'.json');
-                    fs.writeFileSync(filePath, JSON.stringify(dcs));
-                });
-                resp.vocabularies.forEach((vocab, index) => {
-                    const fileName = 'vocabulary_'+ index.toString();
-                    const filePath = path.join(options.output, fileName+'.json');
-                    fs.writeFileSync(filePath, vocab);
-                });
-            }
-            return {
-                models: updatedModels,
-                extractedDecorators: resp.decoratorCommandSet,
-                extractedVocabularies: resp.vocabularies
-            };
+            resp.decoratorCommandSet.forEach((dcs, index) => {
+                const fileName = 'dcs_'+ index.toString();
+                const filePath = path.join(options.output, fileName+'.json');
+                fs.writeFileSync(filePath, JSON.stringify(dcs));
+            });
+            resp.vocabularies.forEach((vocab, index) => {
+                const fileName = 'vocabulary_'+ index.toString();
+                const filePath = path.join(options.output, fileName+'.yml');
+                fs.writeFileSync(filePath, vocab);
+            });
+            return `Extracted Decorators and models in ${options.output}/.`;
         } catch (e) {
             throw new Error(e);
         }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -687,6 +687,68 @@ class Commands {
             throw new Error(e);
         }
     }
+
+    /**
+     * Extract the decorator command sets and vocabularies from a list of modelFiles
+     * @param {string} modelFiles - the model from which vocabularies and decorators have to be extracted
+     * @param {object} options - optional parameters
+     * @param {string} options.locale - locale for extracted vocabularies
+     * @param {string} options.removeDecoratorsFromSource -  the flag to determine whether to remove decorators from source model files
+     * @param {string} options.output -  the output directory where the extracted models, decorators and vocabularies are to be written
+     * @returns {Object} - Extracted models, decorators and vocabularies
+     */
+    static async extractDecorators(modelFiles, options) {
+        try {
+            const updatedModels = [];
+            const allModelContent = modelFiles.map(file => fs.readFileSync(file, 'utf-8'));
+            let modelManager = new ModelManager();
+            allModelContent.forEach(modelContent => {
+                modelManager.addModel(modelContent);
+            });
+
+            const resp = DecoratorManager.extractDecorators(modelManager, options);
+
+            if (options.output) {
+                if (!fs.existsSync(options.output)) {
+                    // If it doesn't exist, create the directory
+                    fs.mkdirSync(options.output);
+                }
+            }
+
+            const namespaces = resp.modelManager.getNamespaces().filter(namespace=>namespace!=='concerto@1.0.0' && namespace!=='concerto');
+            namespaces.forEach(name=>{
+                let model = resp.modelManager.getModelFile(name);
+                let modelAst=model.getAst();
+                let data =  Printer.toCTO(modelAst);
+
+                updatedModels.push(data);
+                if (options.output) {
+                    const filePath = path.join(options.output, model.namespace.split('@')[0]+'.cto');
+                    fs.writeFileSync(filePath, data);
+                }
+            });
+
+            if (options.output) {
+                resp.decoratorCommandSet.forEach((dcs, index) => {
+                    const fileName = 'dcs_'+ index.toString();
+                    const filePath = path.join(options.output, fileName+'.json');
+                    fs.writeFileSync(filePath, JSON.stringify(dcs));
+                });
+                resp.vocabularies.forEach((vocab, index) => {
+                    const fileName = 'vocabulary_'+ index.toString();
+                    const filePath = path.join(options.output, fileName+'.json');
+                    fs.writeFileSync(filePath, vocab);
+                });
+            }
+            return {
+                models: updatedModels,
+                extractedDecorators: resp.decoratorCommandSet,
+                extractedVocabularies: resp.vocabularies
+            };
+        } catch (e) {
+            throw new Error(e);
+        }
+    }
 }
 
 module.exports = Commands;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "3.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "3.13.0",
+        "@accordproject/concerto-analysis": "3.15.0",
         "@accordproject/concerto-codegen": "3.16.0",
         "@accordproject/concerto-core": "3.15.0",
-        "@accordproject/concerto-cto": "3.13.0",
+        "@accordproject/concerto-cto": "3.15.0",
         "@accordproject/concerto-metamodel": "3.9.0",
-        "@accordproject/concerto-util": "3.13.0",
+        "@accordproject/concerto-util": "3.15.0",
         "ansi-colors": "4.1.3",
         "glob": "^7.2.0",
         "randexp": "^0.5.3",
@@ -52,67 +52,16 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.13.0.tgz",
-      "integrity": "sha512-68w0kfgq8gmA/Kx7jMc1nmvqK8a7laDyFj58brF4jDKmM2ehWSwdgMoVoRsAHZygmFSCoSFyxaKaMBzVTK5Fhw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.15.0.tgz",
+      "integrity": "sha512-nBzhzyjsJ5AVUmYWy3y19tElSDd9B2kZuX48bRlmAEVQrsdPp9HfsopQeLsPzEbkAJYn4AxiTo8heoL9a+QQYQ==",
       "dependencies": {
-        "@accordproject/concerto-core": "3.13.0",
+        "@accordproject/concerto-core": "3.15.0",
         "semver": "7.5.4"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.13.0.tgz",
-      "integrity": "sha512-PcUgLVpqa1y0sxuvpA/hQvgpkA/2bEgZZPftUs4udpAH+G1ml0Z2/6qzeyFcmAq9SvEUBfbhcaT0Vf4avXqO8Q==",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.13.0",
-        "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.13.0",
-        "dayjs": "1.10.8",
-        "debug": "4.3.1",
-        "lorem-ipsum": "2.0.3",
-        "randexp": "0.5.3",
-        "semver": "7.5.4",
-        "slash": "3.0.0",
-        "urijs": "1.19.11",
-        "uuid": "8.3.2"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
-      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.9.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
-      "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
-        "colors": "1.4.0",
-        "debug": "4.3.1",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
       }
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/lru-cache": {
@@ -301,47 +250,6 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.15.0.tgz",
-      "integrity": "sha512-78oJJLqKkRB3WWe3UzwHURd4TLyJXAX9aI6Qi/r1txgyAmOEN20mIpgIQxsTc/k50HHqqEsO1tmQBLU+XMX1oA==",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.9.0",
-        "@accordproject/concerto-util": "3.15.0",
-        "path-browserify": "1.0.1"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.15.0.tgz",
-      "integrity": "sha512-Dj4hpoc8WW6LwK6H+nfsI+yfBsYcw60a/KiKkaxiAmmIvsGdvia4rpqwCLSSdT6h3XaetJLXM4LZEZo2RLqO7g==",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.6.0",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@accordproject/concerto-core/node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -429,42 +337,13 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.13.0.tgz",
-      "integrity": "sha512-xdau10/lP7z+dh8G3tr6HUyPg2Dyvgi+f/E5wy2UKQIQWBXVLRG3XDoQ3gA8gsk5yE9B2mFhzbiAzOcz2dGo0w==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.15.0.tgz",
+      "integrity": "sha512-78oJJLqKkRB3WWe3UzwHURd4TLyJXAX9aI6Qi/r1txgyAmOEN20mIpgIQxsTc/k50HHqqEsO1tmQBLU+XMX1oA==",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.13.0",
+        "@accordproject/concerto-metamodel": "3.9.0",
+        "@accordproject/concerto-util": "3.15.0",
         "path-browserify": "1.0.1"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
-      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.9.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
-      "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
-        "colors": "1.4.0",
-        "debug": "4.3.1",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
       },
       "engines": {
         "node": ">=16",
@@ -502,20 +381,46 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.13.0.tgz",
-      "integrity": "sha512-/CzRSNkq4r2QMVp4TijnV1y0P2l0pxryB3w8UOx1BgWvbrgecz4/7xvGlH/WZbcWnUwdxXqA+D8JbhXb4jKhnQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.15.0.tgz",
+      "integrity": "sha512-Dj4hpoc8WW6LwK6H+nfsI+yfBsYcw60a/KiKkaxiAmmIvsGdvia4rpqwCLSSdT6h3XaetJLXM4LZEZo2RLqO7g==",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
+        "axios": "1.6.0",
         "colors": "1.4.0",
-        "debug": "4.3.1",
+        "debug": "4.3.4",
         "json-colorizer": "2.2.2",
         "slash": "3.0.0"
       },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-util/node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/concerto-util/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@accordproject/concerto-vocabulary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@accordproject/concerto-analysis": "3.13.0",
         "@accordproject/concerto-codegen": "3.16.0",
-        "@accordproject/concerto-core": "3.13.0",
+        "@accordproject/concerto-core": "3.15.0",
         "@accordproject/concerto-cto": "3.13.0",
         "@accordproject/concerto-metamodel": "3.9.0",
         "@accordproject/concerto-util": "3.13.0",
@@ -62,6 +62,57 @@
       "engines": {
         "node": ">=14",
         "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.13.0.tgz",
+      "integrity": "sha512-PcUgLVpqa1y0sxuvpA/hQvgpkA/2bEgZZPftUs4udpAH+G1ml0Z2/6qzeyFcmAq9SvEUBfbhcaT0Vf4avXqO8Q==",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.13.0",
+        "@accordproject/concerto-metamodel": "3.8.1",
+        "@accordproject/concerto-util": "3.13.0",
+        "dayjs": "1.10.8",
+        "debug": "4.3.1",
+        "lorem-ipsum": "2.0.3",
+        "randexp": "0.5.3",
+        "semver": "7.5.4",
+        "slash": "3.0.0",
+        "urijs": "1.19.11",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
+      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.9.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
+      "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "0.23.0",
+        "colors": "1.4.0",
+        "debug": "4.3.1",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/lru-cache": {
@@ -229,54 +280,110 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.13.0.tgz",
-      "integrity": "sha512-PcUgLVpqa1y0sxuvpA/hQvgpkA/2bEgZZPftUs4udpAH+G1ml0Z2/6qzeyFcmAq9SvEUBfbhcaT0Vf4avXqO8Q==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.15.0.tgz",
+      "integrity": "sha512-Jw0m5Z3PRshWVsEJeNsVs0v4LobdkEpTZgqihacRuCoq3maIbk8B7lFzhPETKCilt9QkiBAL3Mv9T5cilIQFSQ==",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.13.0",
-        "@accordproject/concerto-metamodel": "3.8.1",
-        "@accordproject/concerto-util": "3.13.0",
-        "dayjs": "1.10.8",
-        "debug": "4.3.1",
-        "lorem-ipsum": "2.0.3",
+        "@accordproject/concerto-cto": "3.15.0",
+        "@accordproject/concerto-metamodel": "3.9.0",
+        "@accordproject/concerto-util": "3.15.0",
+        "dayjs": "1.11.10",
+        "debug": "4.3.4",
+        "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
         "semver": "7.5.4",
         "slash": "3.0.0",
         "urijs": "1.19.11",
-        "uuid": "8.3.2"
+        "uuid": "9.0.1"
       },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.8.1.tgz",
-      "integrity": "sha512-R0CAtzW/IciPz2BxlEyMgKZtya7sqgZ/YSk5iLD6g16NXsJtj6jytDuSZmNMz0B0FpjtEjSoSXPexCR/aPL1qA==",
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.15.0.tgz",
+      "integrity": "sha512-78oJJLqKkRB3WWe3UzwHURd4TLyJXAX9aI6Qi/r1txgyAmOEN20mIpgIQxsTc/k50HHqqEsO1tmQBLU+XMX1oA==",
       "dependencies": {
-        "@accordproject/concerto-util": "3.9.1"
+        "@accordproject/concerto-metamodel": "3.9.0",
+        "@accordproject/concerto-util": "3.15.0",
+        "path-browserify": "1.0.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.9.1.tgz",
-      "integrity": "sha512-LU3bWxURtyDhEEDWct15nOXat5WvFE/Z7yq/NcVeNr9RcKeIazMYxZ8bu+L6P5NJDxRn4FSWDxvL44dELES4+A==",
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.15.0.tgz",
+      "integrity": "sha512-Dj4hpoc8WW6LwK6H+nfsI+yfBsYcw60a/KiKkaxiAmmIvsGdvia4rpqwCLSSdT6h3XaetJLXM4LZEZo2RLqO7g==",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "axios": "0.23.0",
+        "axios": "1.6.0",
         "colors": "1.4.0",
-        "debug": "4.3.1",
+        "debug": "4.3.4",
         "json-colorizer": "2.2.2",
         "slash": "3.0.0"
       },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/lorem-ipsum": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
+      "integrity": "sha512-5RIwHuCb979RASgCJH0VKERn9cQo/+NcAi2BMe9ddj+gp7hujl6BI+qdOG4nVsLDpwWEJwTVYXNKP6BGgbcoGA==",
+      "dependencies": {
+        "commander": "^9.3.0"
+      },
+      "bin": {
+        "lorem-ipsum": "dist/bin/lorem-ipsum.bin.js"
+      },
+      "engines": {
+        "node": ">= 8.x",
+        "npm": ">= 5.x"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/lru-cache": {
@@ -302,6 +409,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/yallist": {
@@ -1410,6 +1529,11 @@
         "node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/axios": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
@@ -1710,6 +1834,17 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1807,6 +1942,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -2257,6 +2400,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fromentries": {
@@ -3217,6 +3373,25 @@
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4034,6 +4209,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "tmp-promise": "3.0.2"
   },
   "dependencies": {
-    "@accordproject/concerto-analysis": "3.13.0",
+    "@accordproject/concerto-analysis": "3.15.0",
     "@accordproject/concerto-codegen": "3.16.0",
     "@accordproject/concerto-core": "3.15.0",
-    "@accordproject/concerto-cto": "3.13.0",
+    "@accordproject/concerto-cto": "3.15.0",
     "@accordproject/concerto-metamodel": "3.9.0",
-    "@accordproject/concerto-util": "3.13.0",
+    "@accordproject/concerto-util": "3.15.0",
     "ansi-colors": "4.1.3",
     "glob": "^7.2.0",
     "randexp": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@accordproject/concerto-analysis": "3.13.0",
     "@accordproject/concerto-codegen": "3.16.0",
-    "@accordproject/concerto-core": "3.13.0",
+    "@accordproject/concerto-core": "3.15.0",
     "@accordproject/concerto-cto": "3.13.0",
     "@accordproject/concerto-metamodel": "3.9.0",
     "@accordproject/concerto-util": "3.13.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -791,16 +791,21 @@ describe('concerto-cli', () => {
         it('should extract the vocabularies and decorators from source model and should not alter the original model by default', async () => {
             const dir = await tmp.dir({ unsafeCleanup: true });
             const options = {
-                locale: 'en-gb'
+                locale: 'en-gb',
+                output: dir.path
             };
             const model = [(path.resolve(__dirname, 'models', 'extract-deco-and-vocab.cto'))];
             const expectedModels = fs.readFileSync(path.resolve(__dirname, 'models', 'extract-deco-and-vocab.cto'),'utf-8');
-            const expectedVocabs = ['locale: en-gb\nnamespace: test@1.0.0\ndeclarations:\n  - Person: Person Class\n    properties:\n      - firstName: HI\n      - bio: some\n        cus: con\n'];
-            const expectedDecos = [JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'extract-expected-deco.json'),'utf-8'))];
+            const expectedVocabs = 'locale: en-gb\nnamespace: test@1.0.0\ndeclarations:\n  - Person: Person Class\n    properties:\n      - firstName: HI\n      - bio: some\n        cus: con\n';
+            const expectedDecos = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'extract-expected-deco.json'),'utf-8'));
             const result = await Commands.extractDecorators(model, options);
-            result.extractedVocabularies.should.deep.equal(expectedVocabs) ;
-            result.extractedDecorators.should.deep.equal(expectedDecos);
-            result.models[0].replace(/[\r\n]+/g, '\n').replace(/[\t\n]+/g, '\n').trim().should.equal(expectedModels.replace(/[\r\n]+/g, '\n').replace(/[\t\n]+/g, '\n').trim());
+            const actualModels = fs.readFileSync(path.resolve(dir.path, 'test.cto'),'utf-8');
+            const actualVocabs = fs.readFileSync(path.resolve(dir.path, 'vocabulary_0.yml'),'utf-8');
+            const actualDecorators = JSON.parse(fs.readFileSync(path.resolve(dir.path, 'dcs_0.json'),'utf-8'));
+            result.should.include('Extracted Decorators and models in');
+            actualDecorators.should.eql(expectedDecos);
+            actualVocabs.should.eql(expectedVocabs);
+            actualModels.replace(/[\r\n]+/g, '\n').trim().should.eql(expectedModels.replace(/[\r\n]+/g, '\n').trim());
             dir.cleanup();
         });
         it('should throw error if data is invalid', async () => {
@@ -819,16 +824,21 @@ describe('concerto-cli', () => {
             const dir = await tmp.dir({ unsafeCleanup: true });
             const options = {
                 locale: 'en-gb',
-                removeDecoratorsFromModel: true
+                removeDecoratorsFromModel: true,
+                output: dir.path
             };
             const model = [(path.resolve(__dirname, 'models', 'extract-deco-and-vocab.cto'))];
             const expectedModels = fs.readFileSync(path.resolve(__dirname, 'models', 'extracted-model.cto'),'utf-8');
-            const expectedVocabs = ['locale: en-gb\nnamespace: test@1.0.0\ndeclarations:\n  - Person: Person Class\n    properties:\n      - firstName: HI\n      - bio: some\n        cus: con\n'];
-            const expectedDecos = [JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'extract-expected-deco.json'),'utf-8'))];
+            const expectedVocabs = 'locale: en-gb\nnamespace: test@1.0.0\ndeclarations:\n  - Person: Person Class\n    properties:\n      - firstName: HI\n      - bio: some\n        cus: con\n';
+            const expectedDecos = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'data', 'extract-expected-deco.json'),'utf-8'));
             const result = await Commands.extractDecorators(model, options);
-            result.extractedVocabularies.should.deep.equal(expectedVocabs) ;
-            result.extractedDecorators.should.deep.equal(expectedDecos);
-            result.models[0].replace(/[\r\n]+/g, '\n').trim().should.equal(expectedModels.replace(/[\r\n]+/g, '\n').trim());
+            const actualModels = fs.readFileSync(path.resolve(dir.path, 'test.cto'),'utf-8');
+            const actualVocabs = fs.readFileSync(path.resolve(dir.path, 'vocabulary_0.yml'),'utf-8');
+            const actualDecorators = JSON.parse(fs.readFileSync(path.resolve(dir.path, 'dcs_0.json'),'utf-8'));
+            result.should.include('Extracted Decorators and models');
+            actualDecorators.should.eql(expectedDecos);
+            actualVocabs.should.eql(expectedVocabs);
+            actualModels.replace(/[\r\n]+/g, '\n').trim().should.eql(expectedModels.replace(/[\r\n]+/g, '\n').trim());
             dir.cleanup();
         });
         it('should extract the vocabularies and decorators from source model and write result in given folder', async () => {

--- a/test/data/extract-expected-deco.json
+++ b/test/data/extract-expected-deco.json
@@ -1,0 +1,255 @@
+
+    {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet",
+      "name": "test",
+      "version": "1.0.0",
+      "commands": [
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Dummy"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "deco"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Dummy",
+            "property": "One"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "one"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "SSN"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "scc"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "participantName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "M1"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "participantName",
+            "property": "participantKey"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "M3"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Editable"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Custom"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "bio"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "textArea"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "bio"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "ssn"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "ssn"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        }
+      ]
+    }
+

--- a/test/models/extract-deco-and-vocab.cto
+++ b/test/models/extract-deco-and-vocab.cto
@@ -1,0 +1,34 @@
+namespace test@1.0.0
+@deco
+enum Dummy {
+  @one
+  o One
+}
+@scc
+scalar SSN extends String default="000-00-0000"
+@M1
+participant participantName identified by participantKey {
+  @M3
+  o String participantKey
+}
+
+@Term("Person Class")
+@Editable
+concept Person {
+  @Term("HI")
+  @Custom
+  @Form("inputType","text")
+  @New
+  o String firstName
+  @Form("inputType","text")
+  @New
+  o String lastName
+  @Term("some")
+  @Term_cus("con")
+  @Form("inputType","textArea")
+  @New
+  o String bio
+  @Form("inputType","text")
+  @New
+  o String ssn
+}

--- a/test/models/extracted-model.cto
+++ b/test/models/extracted-model.cto
@@ -1,0 +1,18 @@
+namespace test@1.0.0
+
+enum Dummy {
+  o One
+}
+
+scalar SSN extends String default="000-00-0000"
+
+participant participantName identified by participantKey {
+  o String participantKey
+}
+
+concept Person {
+  o String firstName
+  o String lastName
+  o String bio
+  o String ssn
+}


### PR DESCRIPTION
# Closes #43 
Added support to extract decorators and vocabularies from model files

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
