### PR TITLE
feat(generate): add option to disable output validation

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
     mocha: true
 extends: 'eslint:recommended'
 parserOptions:
-    ecmaVersion: 8
+    ecmaVersion: 2020
     sourceType: 'script'
 rules:
     indent:

--- a/index.js
+++ b/index.js
@@ -395,11 +395,17 @@ require('yargs')
             type: 'boolean',
             default: false,
         });
+        yargs.option('disableValidation', {
+            describe: 'Do not validate generated output',
+            type: 'boolean',
+            default: false
+        });
     }, argv => {
         return Commands.generate(argv.model, argv.concept, argv.mode, {
             optionalFields: argv.includeOptionalFields,
             metamodel: argv.metamodel,
             strict: argv.strict,
+            disableValidation: argv.disableValidation
         })
             .then(obj => {
                 console.log(JSON.stringify(obj, null, 2));

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -305,6 +305,7 @@ class Commands {
      * @param {string}  [options.optionalFields] if true, optional fields will be included in the output
      * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {boolean} [options.metamodel] - include the Concerto Metamodel
+     * @param {boolean} [options.disableValidation] - do not validate the generated output 
      */
     static async generate(ctoFiles, concept, mode, options) {
         const modelManagerOptions = { offline: options && options.offline, strict: options && options.strict };
@@ -342,7 +343,7 @@ class Commands {
         );
         const serializer = new Serializer(factory, modelManager);
 
-        return Promise.resolve(serializer.toJSON(resource));
+        return Promise.resolve(serializer.toJSON(resource, {validate: !options?.disableValidation}));
     }
 
     /**

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -305,7 +305,7 @@ class Commands {
      * @param {string}  [options.optionalFields] if true, optional fields will be included in the output
      * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {boolean} [options.metamodel] - include the Concerto Metamodel
-     * @param {boolean} [options.disableValidation] - do not validate the generated output 
+     * @param {boolean} [options.disableValidation] - do not validate the generated output
      */
     static async generate(ctoFiles, concept, mode, options) {
         const modelManagerOptions = { offline: options && options.offline, strict: options && options.strict };


### PR DESCRIPTION
Adds an option to the `generate` command to disable output validation.
This works around any bugs where the sample generation creates invalid output.

### Changes

```
--disableValidation      Do not validate generated output
                                                      [boolean] [default: false]
```

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
