### PR TITLE
feat(validate): add command to validate JSON AST against Concerto met…

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const Logger = require('@accordproject/concerto-util').Logger;
 const fs = require('fs');
 const { glob } = require('glob');
 const Commands = require('./lib/commands');
-const c = require('ansi-colors');
 
 require('yargs')
     .scriptName('concerto')
@@ -278,19 +277,9 @@ require('yargs')
         try {
             const inputString = fs.readFileSync(argv.input, 'utf8');
             const json = JSON.parse(inputString);
-            const validationResult = Commands.validateAST(json, argv.strict);
-            if (validationResult.valid) {
-                Logger.info(c.green('AST is valid'));
-                return true;
-            } else {
-                Logger.error('AST validation failed:');
-                validationResult.errors.forEach(error => {
-                    Logger.error(` - ${error}`);
-                });
-                process.exit(1);
-            }
+            Commands.validateAST(json);
         } catch (err) {
-            Logger.error(`Error validating AST: ${err.message}`);
+            Logger.error('Error validating AST');
             process.exit(1);
         }
     })

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -272,9 +272,9 @@ class Commands {
      */
     static validateAST(ast) {
 
-        const metaModelManager = new ModelManager();
-        // Load the official Concerto Metamodel CTO definition
-        metaModelManager.addCTOModel(MetaModelUtil.metaModelCto);
+        const metaModelManager = new ModelManager({
+            addMetamodel: true
+        });
 
         const factory = new Factory(metaModelManager);
         const serializer = new Serializer(factory, metaModelManager);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -243,23 +243,22 @@ class Commands {
         let json;
         try {
             json = JSON.parse(inputString);
-        } catch (e) {
-            throw new Error(`Failed to parse metamodel: ${e.message}`);
+        } catch (error) {
+            throw new Error(`Failed to parse metamodel: ${error.message}`);
         }
 
-        // Validate the AST before printing
-        const validationResult = Commands.validateAST(json);
-        if (!validationResult.valid) {
-            throw new Error(
-                `Invalid Concerto AST: ${validationResult.errors.join(', ')}`
-            );
+        try{
+            // Validate the AST before printing
+            this.validateAST(json);
+        } catch (error){
+            throw new Error(error.message);
         }
 
         const result = Printer.toCTO(json);
         if (outputPath) {
             Logger.info('Creating file: ' + outputPath);
             fs.writeFileSync(outputPath, result);
-            return;
+            return; // Return nothing if writing to file
         }
         return result;
     }
@@ -268,93 +267,27 @@ class Commands {
      * Validates a Concerto JSON Abstract Syntax Tree (AST)
      *
      * @param {object} ast - The AST to validate
-     * @param {boolean} [strict=true] - Whether to perform strict validation
-     * @returns {object} - Validation result with valid flag and errors array
+     * @returns {string} Success message
+     * @throws {Error} If validation fails or file cannot be read/parsed.
      */
-    static validateAST(ast, strict = true) {
-        const errors = [];
-        let valid = true;
+    static validateAST(ast) {
+
+        const metaModelManager = new ModelManager();
+        // Load the official Concerto Metamodel CTO definition
+        metaModelManager.addCTOModel(MetaModelUtil.metaModelCto);
+
+        const factory = new Factory(metaModelManager);
+        const serializer = new Serializer(factory, metaModelManager);
 
         try {
-            // Check if the AST has the expected structure
-            if (!ast) {
-                errors.push('AST is null or undefined');
-                return { valid: false, errors };
-            }
-
-            // For model type, validate the structure based on Concerto metamodel
-            if (ast.$class === 'concerto.metamodel@1.0.0.Model') {
-                // Validate namespace
-                if (!ast.namespace) {
-                    errors.push('Model must have a namespace');
-                    valid = false;
-                }
-
-                // Validate declarations
-                if (!Array.isArray(ast.declarations)) {
-                    errors.push('Model declarations must be an array');
-                    valid = false;
-                } else {
-                    // Check each declaration
-                    ast.declarations.forEach((declaration, index) => {
-                        if (!declaration.$class) {
-                            errors.push(
-                                `Declaration at index ${index} must have a $class property`
-                            );
-                            valid = false;
-                        }
-
-                        if (!declaration.name) {
-                            errors.push(
-                                `Declaration at index ${index} must have a name property`
-                            );
-                            valid = false;
-                        }
-                    });
-                }
-            } else if (ast.$class === 'concerto.metamodel@1.0.0.Models') {
-                // Validate Models container
-                if (!Array.isArray(ast.models)) {
-                    errors.push('Models must have a models array');
-                    valid = false;
-                } else {
-                    // Validate each model in the array
-                    ast.models.forEach((model, index) => {
-                        const modelResult = Commands.validateAST(model, strict);
-                        if (!modelResult.valid) {
-                            valid = false;
-                            errors.push(
-                                `Model at index ${index} is invalid: ${modelResult.errors.join(
-                                    ', '
-                                )}`
-                            );
-                        }
-                    });
-                }
-            } else if (!ast.$class) {
-                errors.push(
-                    'AST must have a $class property defining its type'
-                );
-                valid = false;
-            }
-
-            // Use MetaModelUtil for additional validation if available
-            if (strict && MetaModelUtil.validateMetaModel) {
-                try {
-                    MetaModelUtil.validateMetaModel(ast);
-                } catch (validationError) {
-                    errors.push(
-                        `MetaModel validation error: ${validationError.message}`
-                    );
-                    valid = false;
-                }
-            }
+            // deserialize the user's AST using the metamodel's rules.
+            // This will validates the structure, types, and constraints ($class, required fields etc.)
+            // defined in concerto.metamodel@1.0.0.cto
+            serializer.fromJSON(ast);
         } catch (error) {
-            errors.push(`Unexpected error during validation: ${error.message}`);
-            valid = false;
+            throw new Error(`Invalid Concerto Metamodel AST: ${error.message}`);
         }
-
-        return { valid, errors };
+        return 'Concerto Metamodel AST is valid.';
     }
 
     /**

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -240,7 +240,21 @@ class Commands {
      */
     static async print(input, outputPath) {
         const inputString = fs.readFileSync(input, 'utf8');
-        const json = JSON.parse(inputString);
+        let json;
+        try {
+            json = JSON.parse(inputString);
+        } catch (e) {
+            throw new Error(`Failed to parse metamodel: ${e.message}`);
+        }
+
+        // Validate the AST before printing
+        const validationResult = Commands.validateAST(json);
+        if (!validationResult.valid) {
+            throw new Error(
+                `Invalid Concerto AST: ${validationResult.errors.join(', ')}`
+            );
+        }
+
         const result = Printer.toCTO(json);
         if (outputPath) {
             Logger.info('Creating file: ' + outputPath);
@@ -248,6 +262,99 @@ class Commands {
             return;
         }
         return result;
+    }
+
+    /**
+     * Validates a Concerto JSON Abstract Syntax Tree (AST)
+     *
+     * @param {object} ast - The AST to validate
+     * @param {boolean} [strict=true] - Whether to perform strict validation
+     * @returns {object} - Validation result with valid flag and errors array
+     */
+    static validateAST(ast, strict = true) {
+        const errors = [];
+        let valid = true;
+
+        try {
+            // Check if the AST has the expected structure
+            if (!ast) {
+                errors.push('AST is null or undefined');
+                return { valid: false, errors };
+            }
+
+            // For model type, validate the structure based on Concerto metamodel
+            if (ast.$class === 'concerto.metamodel@1.0.0.Model') {
+                // Validate namespace
+                if (!ast.namespace) {
+                    errors.push('Model must have a namespace');
+                    valid = false;
+                }
+
+                // Validate declarations
+                if (!Array.isArray(ast.declarations)) {
+                    errors.push('Model declarations must be an array');
+                    valid = false;
+                } else {
+                    // Check each declaration
+                    ast.declarations.forEach((declaration, index) => {
+                        if (!declaration.$class) {
+                            errors.push(
+                                `Declaration at index ${index} must have a $class property`
+                            );
+                            valid = false;
+                        }
+
+                        if (!declaration.name) {
+                            errors.push(
+                                `Declaration at index ${index} must have a name property`
+                            );
+                            valid = false;
+                        }
+                    });
+                }
+            } else if (ast.$class === 'concerto.metamodel@1.0.0.Models') {
+                // Validate Models container
+                if (!Array.isArray(ast.models)) {
+                    errors.push('Models must have a models array');
+                    valid = false;
+                } else {
+                    // Validate each model in the array
+                    ast.models.forEach((model, index) => {
+                        const modelResult = Commands.validateAST(model, strict);
+                        if (!modelResult.valid) {
+                            valid = false;
+                            errors.push(
+                                `Model at index ${index} is invalid: ${modelResult.errors.join(
+                                    ', '
+                                )}`
+                            );
+                        }
+                    });
+                }
+            } else if (!ast.$class) {
+                errors.push(
+                    'AST must have a $class property defining its type'
+                );
+                valid = false;
+            }
+
+            // Use MetaModelUtil for additional validation if available
+            if (strict && MetaModelUtil.validateMetaModel) {
+                try {
+                    MetaModelUtil.validateMetaModel(ast);
+                } catch (validationError) {
+                    errors.push(
+                        `MetaModel validation error: ${validationError.message}`
+                    );
+                    valid = false;
+                }
+            }
+        } catch (error) {
+            errors.push(`Unexpected error during validation: ${error.message}`);
+            valid = false;
+        }
+
+        return { valid, errors };
     }
 
     /**
@@ -293,7 +400,6 @@ class Commands {
             process.exit(1);
         }
     }
-
 
     /**
      * Generate a sample JSON instance of a Concept

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -243,14 +243,9 @@ class Commands {
         let json;
         try {
             json = JSON.parse(inputString);
-        } catch (error) {
-            throw new Error(`Failed to parse metamodel: ${error.message}`);
-        }
-
-        try{
             // Validate the AST before printing
             this.validateAST(json);
-        } catch (error){
+        } catch (error) {
             throw new Error(error.message);
         }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -30,6 +30,7 @@ global.fetch = fetch;
 
 const Commands = require('../lib/commands');
 const { Parser } = require('@accordproject/concerto-cto');
+const { MetaModelUtil } = require('@accordproject/concerto-metamodel');
 
 describe('concerto-cli', () => {
     const models = [path.resolve(__dirname, 'models/dom.cto'),path.resolve(__dirname, 'models/money.cto')];
@@ -322,6 +323,46 @@ describe('concerto-cli', () => {
             const result = fs.readFileSync(output.path, 'utf-8');
             result.should.equal(expected);
             output.cleanup();
+        });
+        it('should handle invalid JSON metamodel content', async () => {
+            const tempFile = await tmp.file({ unsafeCleanup: true });
+            fs.writeFileSync(tempFile.path, 'This is not valid JSON', 'utf-8');
+            try {
+                await Commands.print(tempFile.path);
+                expect.fail('Expected error was not thrown');
+            } catch (err) {
+                err.should.be.an.instanceOf(Error);
+                err.message.should.match(/Failed to parse metamodel/);
+            } finally {
+                tempFile.cleanup();
+            }
+        });
+        it('should handle file not found errors', async () => {
+            try {
+                await Commands.print('/path/to/nonexistent/file.json');
+                expect.fail('Expected error was not thrown');
+            } catch (err) {
+                err.should.be.an.instanceOf(Error);
+            }
+        });
+        it('should handle invalid AST validation in metamodel', async () => {
+            const tempFile = await tmp.file({ unsafeCleanup: true });
+            const invalidAST = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                imports: [],
+                declarations: []
+            };
+            fs.writeFileSync(tempFile.path, JSON.stringify(invalidAST), 'utf-8');
+            try {
+                await Commands.print(tempFile.path);
+                expect.fail('Expected error was not thrown');
+            } catch (err) {
+                err.should.be.an.instanceOf(Error);
+                err.message.should.include('Invalid Concerto AST:');
+                err.message.should.include('Model must have a namespace');
+            } finally {
+                tempFile.cleanup();
+            }
         });
     });
 
@@ -869,6 +910,212 @@ describe('concerto-cli', () => {
             const threeFilesExist = files.length === 6;
             expect(threeFilesExist).to.be.true;
             dir.cleanup();
+        });
+    });
+
+    describe('#validateAST', () => {
+        it('should validate a valid Model AST', () => {
+            const validModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: []
+            };
+
+            const result = Commands.validateAST(validModel);
+            result.should.have.property('valid', true);
+            result.should.have.property('errors').with.lengthOf(0);
+        });
+
+        it('should validate a Models container with valid models', () => {
+            const validModels = {
+                $class: 'concerto.metamodel@1.0.0.Models',
+                models: [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.Model',
+                        namespace: 'org.example1@1.0.0',
+                        imports: [],
+                        declarations: []
+                    },
+                    {
+                        $class: 'concerto.metamodel@1.0.0.Model',
+                        namespace: 'org.example2@1.0.0',
+                        imports: [],
+                        declarations: []
+                    }
+                ]
+            };
+
+            const result = Commands.validateAST(validModels);
+            result.should.have.property('valid', true);
+            result.should.have.property('errors').with.lengthOf(0);
+        });
+
+        it('should detect missing namespace in Model', () => {
+            const invalidModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                imports: [],
+                declarations: []
+            };
+
+            const result = Commands.validateAST(invalidModel);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Model must have a namespace');
+        });
+
+        it('should detect missing declarations array in Model', () => {
+            const invalidModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: []
+            };
+
+            const result = Commands.validateAST(invalidModel);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Model declarations must be an array');
+        });
+
+        it('should detect invalid declaration without $class', () => {
+            const invalidModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: [
+                    {
+                        name: 'MyClass',
+                        properties: []
+                    }
+                ]
+            };
+
+            const result = Commands.validateAST(invalidModel);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Declaration at index 0 must have a $class property');
+        });
+
+        it('should detect invalid declaration without name', () => {
+            const invalidModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                        properties: []
+                    }
+                ]
+            };
+
+            const result = Commands.validateAST(invalidModel);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Declaration at index 0 must have a name property');
+        });
+
+        it('should detect missing models array in Models container', () => {
+            const invalidModels = {
+                $class: 'concerto.metamodel@1.0.0.Models',
+            };
+
+            const result = Commands.validateAST(invalidModels);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Models must have a models array');
+        });
+
+        it('should detect invalid model in Models container', () => {
+            const invalidModels = {
+                $class: 'concerto.metamodel@1.0.0.Models',
+                models: [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.Model',
+                        imports: [],
+                        declarations: []
+                    }
+                ]
+            };
+
+            const result = Commands.validateAST(invalidModels);
+            result.should.have.property('valid', false);
+            result.errors[0].should.include('Model at index 0 is invalid');
+        });
+
+        it('should detect missing $class property', () => {
+            const invalidAST = {
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: []
+            };
+
+            const result = Commands.validateAST(invalidAST);
+            result.should.have.property('valid', false);
+            result.errors.should.include('AST must have a $class property defining its type');
+        });
+
+        it('should validate with strict mode off', () => {
+            const validModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: []
+            };
+            const result = Commands.validateAST(validModel, false);
+            result.should.have.property('valid', true);
+            result.should.have.property('errors').with.lengthOf(0);
+        });
+
+        it('should handle null/undefined AST', () => {
+            const result = Commands.validateAST(null);
+            result.should.have.property('valid', false);
+            result.errors.should.include('AST is null or undefined');
+        });
+
+        it('should handle validation errors from MetaModelUtil', () => {
+            const originalValidateMetaModel = MetaModelUtil.validateMetaModel;
+            MetaModelUtil.validateMetaModel = function() {
+                throw new Error('Validation failed');
+            };
+            const validModel = {
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.example@1.0.0',
+                imports: [],
+                declarations: []
+            };
+            try {
+                const result = Commands.validateAST(validModel);
+                result.should.have.property('valid', false);
+                result.errors.should.include('MetaModel validation error: Validation failed');
+            } finally {
+                MetaModelUtil.validateMetaModel = originalValidateMetaModel;
+            }
+        });
+
+        it('should handle unexpected errors during validation', () => {
+            const badModel = {};
+            Object.defineProperty(badModel, '$class', {
+                get: function() { throw new Error('Unexpected error'); }
+            });
+            const result = Commands.validateAST(badModel);
+            result.should.have.property('valid', false);
+            result.errors.should.include('Unexpected error during validation: Unexpected error');
+        });
+
+        it('should handle AST with unsupported type', () => {
+            const unsupportedModel = {
+                $class: 'concerto.metamodel@1.0.0.UnknownType',
+                someProperty: 'test'
+            };
+            const result = Commands.validateAST(unsupportedModel);
+            result.should.have.property('valid', true);
+            result.should.have.property('errors').with.lengthOf(0);
+        });
+
+        it('should validate a Models container with an empty models array', () => {
+            const emptyModelsContainer = {
+                $class: 'concerto.metamodel@1.0.0.Models',
+                models: []
+            };
+            const result = Commands.validateAST(emptyModelsContainer);
+            result.should.have.property('valid', true);
+            result.should.have.property('errors').with.lengthOf(0);
         });
     });
 });


### PR DESCRIPTION

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: 
This pull request introduces a new command to validate a JSON Abstract Syntax Tree (AST) against the Concerto metamodel, along with various improvements and tests for error handling and validation. The most important changes include adding the `validate-ast` command, implementing the `validateAST` method, and adding comprehensive test cases for the new functionality.

New command and functionality:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R266-R296): Added the `validate-ast` command to validate a JSON syntax tree against the Concerto metamodel.

Validation method:

* [`lib/commands.js`](diffhunk://#diff-06278636f1999ab48dcce4990fbbc199d6cc4e215f8c83f4b413655cb65301a4R267-R359): Implemented the `validateAST` method to check the structure of the AST.

Error handling improvements:

* [`lib/commands.js`](diffhunk://#diff-06278636f1999ab48dcce4990fbbc199d6cc4e215f8c83f4b413655cb65301a4L243-R257): Updated the `print` method to include error handling for JSON parsing and AST validation, throwing descriptive errors when validation fails.

Testing enhancements:

* [`test/cli.js`](diffhunk://#diff-aae216853526bb5eb76ffeff66cc7f56184296adde901fd9d48c08e925723a8aR327-R366): Added tests to handle various error scenarios, including invalid JSON content, file not found errors, and invalid AST validation.
* [`test/cli.js`](diffhunk://#diff-aae216853526bb5eb76ffeff66cc7f56184296adde901fd9d48c08e925723a8aR915-R1120): Added tests for the `validateAST` method to ensure it correctly validates different AST structures and handles various edge cases.

Dependency updates:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R22): Added the `ansi-colors` package to colorize log messages for better readability.-->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #55 
<!--- Provide an overall summary of the pull request -->

### Changes
### New Command Addition:
* Added a new `validate-ast` command to the CLI, which validates a JSON syntax tree against the Concerto metamodel.
### Error Handling Improvements:
* Improved error handling in the `print` method to catch and report JSON parsing errors and invalid AST structures. (`lib/commands.js`)
* Added comprehensive error messages for various validation failures in the `validateAST` method. (`lib/commands.js`)

### Validation Enhancements:
* Introduced a new `validateAST` method in the `Commands` class to validate a Concerto JSON AST. This method checks for the correct structure, required properties. (`lib/commands.js`)

### Test Coverage Expansion:
* Added tests for the new `validateAST` method to cover various scenarios, including valid and invalid models, missing properties, and error handling. (`test/cli.js`)
* Enhanced existing tests to handle invalid JSON content, file not found errors, and invalid AST validation. (`test/cli.js`)



### Related Issues
- Issue #55

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
