### PR TITLE
feat(convert-dcs): CLI Support for DCS JSON <-> YAML Conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,6 +499,34 @@ require('yargs')
                 Logger.error(err.message);
             });
     })
+    .command('convert-dcs', 'convert decorator command set between JSON and YAML formats', (yargs) => {
+        yargs.demandOption('dcs', 'Please provide a DCS file');
+        yargs.option('dcs', {
+            describe: 'The input DCS file (.json or .yaml/.yml)',
+            type: 'string'
+        });
+        yargs.option('output', {
+            describe: 'The output file path (.json or .yaml/.yml). If not provided, outputs to console',
+            type: 'string'
+        });
+    }, (argv) => {
+        return Commands.convertDcs(argv.dcs, argv.output)
+            .then((result) => {
+                if (!argv.output) {
+                    // Output to console with proper formatting
+                    if (typeof result === 'string') {
+                        console.log(result);
+                    } else {
+                        console.log(JSON.stringify(result, null, 4));
+                    }
+                } else {
+                    Logger.info(result);
+                }
+            })
+            .catch((err) => {
+                Logger.error(err.message);
+            });
+    })
     .option('verbose', {
         alias: 'v',
         default: false

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -780,6 +780,71 @@ class Commands {
             throw new Error(e);
         }
     }
+
+    /**
+     * Convert decorator command set between JSON and YAML formats
+     * @param {string} dcsFile - the input DCS file path (.json or .yaml/.yml)
+     * @param {string} [outputFile] - the output file path (.json or .yaml/.yml). If not provided, returns the converted content
+     * @returns {string|Object} - the converted content (string for YAML, object for JSON when outputting to console)
+     */
+    static async convertDcs(dcsFile, outputFile) {
+        try {
+            if (!fs.existsSync(dcsFile)) {
+                throw new Error(`DCS file does not exist: ${dcsFile}`);
+            }
+
+            const inputContent = fs.readFileSync(dcsFile, 'utf-8');
+            const inputExt = path.extname(dcsFile).toLowerCase();
+
+            let convertedContent;
+            let isOutputYaml = false;
+
+            // Determine input format and convert
+            if (inputExt === '.json') {
+                const jsonObject = JSON.parse(inputContent);
+                convertedContent = DecoratorManager.jsonToYaml(jsonObject);
+                isOutputYaml = true;
+            }
+            else if (inputExt === '.yaml' || inputExt === '.yml') {
+                convertedContent = DecoratorManager.yamlToJson(inputContent);
+                isOutputYaml = false;
+            }
+            else {
+                throw new Error(`Unsupported input file format: ${inputExt}. Supported formats: .json, .yaml, .yml`);
+            }
+
+            // Handle output
+            if (outputFile) {
+                const outputExt = path.extname(outputFile).toLowerCase();
+
+                if (isOutputYaml && outputExt !== '.yaml' && outputExt !== '.yml') {
+                    throw new Error(`Output file extension should be .yaml or .yml when converting from JSON, got: ${outputExt}`);
+                }
+                if (!isOutputYaml && outputExt !== '.json') {
+                    throw new Error(`Output file extension should be .json when converting from YAML, got: ${outputExt}`);
+                }
+
+                // Ensure output directory exists
+                const outputDir = path.dirname(outputFile);
+                if (!fs.existsSync(outputDir)) {
+                    fs.mkdirSync(outputDir, { recursive: true });
+                }
+
+                // Write the converted content
+                if (isOutputYaml) {
+                    fs.writeFileSync(outputFile, convertedContent);
+                } else {
+                    fs.writeFileSync(outputFile, JSON.stringify(convertedContent, null, 4));
+                }
+                return `Successfully converted ${dcsFile} to ${outputFile}`;
+            }
+            else {
+                return convertedContent;
+            }
+        } catch (e) {
+            throw new Error(`DCS conversion failed: ${e.message}`);
+        }
+    }
 }
 
 module.exports = Commands;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "3.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "3.20.4",
+        "@accordproject/concerto-analysis": "3.23.0",
         "@accordproject/concerto-codegen": "3.30.5",
         "@accordproject/concerto-core": "3.23.0",
-        "@accordproject/concerto-cto": "3.20.4",
+        "@accordproject/concerto-cto": "3.23.0",
         "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4",
+        "@accordproject/concerto-util": "3.23.0",
         "ansi-colors": "4.1.3",
         "glob": "^7.2.3",
         "randexp": "^0.5.3",
@@ -44,63 +44,18 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.20.4.tgz",
-      "integrity": "sha512-6tXaGgJHydSVsfDr3+XW3KErPrVImeCd8mZthZQta1jZ8RTCqPRMP6xtnPNOSxET9fDJ5c+0MKmAvfepgj6WRw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.23.0.tgz",
+      "integrity": "sha512-43JFp937RXuoOvXO5ynk+r8tofVCVivkUpv8OonuqOaXcx3zKqalQZQ1WSzbRq881t1duHUrmTKTubxvVC90LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.20.4",
+        "@accordproject/concerto-core": "3.23.0",
         "semver": "7.6.3"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.4.tgz",
-      "integrity": "sha512-ebKNJxpMOf+mygUq66+eQWBjd9xIL+xovlpztbREfhDkLd3GrfYM6t+rUxUeIplSc5zzY9K+nyQyVWWKa9qCZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.20.4",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/semver": {
       "version": "7.6.3",
@@ -263,20 +218,6 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.23.0.tgz",
-      "integrity": "sha512-O2GlY2iU8jSyO98QLEiD8cDusrkcSEV0m4XEkFmRDz0H+O+nS1veRTND36j1ZtvK0UwOlc49Z5aqM7CDWrniug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.4",
-        "@accordproject/concerto-util": "3.23.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
     "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
       "version": "3.12.4",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
@@ -285,21 +226,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.23.0.tgz",
-      "integrity": "sha512-q9BIu2ww14Y0bxlgkDiZBzyR1V21miMT84ykN+FObo+S0rhY3Uxcgspvz8VZqfzV7PJBqrX+9Uz+WTaSAMgtGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/debug": {
@@ -350,17 +276,27 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.20.4.tgz",
-      "integrity": "sha512-Rdn8AgfAW8h8A3onqBduSvD/NioyG8xZtnPWd1qIvytXs4wyQiCnghulJulvIBUiDoOY97Im7RhknU6Tn3YwjQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.23.0.tgz",
+      "integrity": "sha512-O2GlY2iU8jSyO98QLEiD8cDusrkcSEV0m4XEkFmRDz0H+O+nS1veRTND36j1ZtvK0UwOlc49Z5aqM7CDWrniug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4"
+        "@accordproject/concerto-metamodel": "3.12.4",
+        "@accordproject/concerto-util": "3.23.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
+      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
       }
     },
     "node_modules/@accordproject/concerto-metamodel": {
@@ -374,9 +310,9 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.20.4.tgz",
-      "integrity": "sha512-Dyqep4H/rwPIw9KgZJoYl+QUT/C/e7KquvovcOXspl9dxBNXYCxyvLbp8DE+xVu1MWR0LD9K3sjLzfLa5QKChg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.23.0.tgz",
+      "integrity": "sha512-q9BIu2ww14Y0bxlgkDiZBzyR1V21miMT84ykN+FObo+S0rhY3Uxcgspvz8VZqfzV7PJBqrX+9Uz+WTaSAMgtGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@accordproject/concerto-analysis": "3.20.4",
         "@accordproject/concerto-codegen": "3.30.5",
-        "@accordproject/concerto-core": "3.20.4",
+        "@accordproject/concerto-core": "3.23.0",
         "@accordproject/concerto-cto": "3.20.4",
         "@accordproject/concerto-metamodel": "3.11.0",
         "@accordproject/concerto-util": "3.20.4",
@@ -56,6 +56,51 @@
         "node": ">=18",
         "npm": ">=10"
       }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.4.tgz",
+      "integrity": "sha512-ebKNJxpMOf+mygUq66+eQWBjd9xIL+xovlpztbREfhDkLd3GrfYM6t+rUxUeIplSc5zzY9K+nyQyVWWKa9qCZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.20.4",
+        "@accordproject/concerto-metamodel": "3.11.0",
+        "@accordproject/concerto-util": "3.20.4",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/concerto-analysis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/semver": {
       "version": "7.6.3",
@@ -195,21 +240,62 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.4.tgz",
-      "integrity": "sha512-ebKNJxpMOf+mygUq66+eQWBjd9xIL+xovlpztbREfhDkLd3GrfYM6t+rUxUeIplSc5zzY9K+nyQyVWWKa9qCZw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.23.0.tgz",
+      "integrity": "sha512-W0gEnwQnG6mODtEMHjsvKIy3FoyloZRMZhgMnbghX+mu9ZmLd5wjcFTJ1h97qJuFn3+P069LDtbu9mz+tt6Y+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.20.4",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4",
+        "@accordproject/concerto-cto": "3.23.0",
+        "@accordproject/concerto-metamodel": "^3.12.4",
+        "@accordproject/concerto-util": "3.23.0",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
+        "rfdc": "1.4.1",
         "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "11.0.3"
+        "uuid": "11.0.3",
+        "yaml": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.23.0.tgz",
+      "integrity": "sha512-O2GlY2iU8jSyO98QLEiD8cDusrkcSEV0m4XEkFmRDz0H+O+nS1veRTND36j1ZtvK0UwOlc49Z5aqM7CDWrniug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.12.4",
+        "@accordproject/concerto-util": "3.23.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
+      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.23.0.tgz",
+      "integrity": "sha512-q9BIu2ww14Y0bxlgkDiZBzyR1V21miMT84ykN+FObo+S0rhY3Uxcgspvz8VZqfzV7PJBqrX+9Uz+WTaSAMgtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "debug": "4.3.7",
+        "slash": "3.0.0"
       },
       "engines": {
         "node": ">=18",
@@ -249,6 +335,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/@accordproject/concerto-cto": {
@@ -4108,6 +4206,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@accordproject/concerto-analysis": "3.20.4",
     "@accordproject/concerto-codegen": "3.30.5",
-    "@accordproject/concerto-core": "3.20.4",
+    "@accordproject/concerto-core": "3.23.0",
     "@accordproject/concerto-cto": "3.20.4",
     "@accordproject/concerto-metamodel": "3.11.0",
     "@accordproject/concerto-util": "3.20.4",

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "tmp-promise": "3.0.2"
   },
   "dependencies": {
-    "@accordproject/concerto-analysis": "3.20.4",
+    "@accordproject/concerto-analysis": "3.23.0", 
     "@accordproject/concerto-codegen": "3.30.5",
     "@accordproject/concerto-core": "3.23.0",
-    "@accordproject/concerto-cto": "3.20.4",
+    "@accordproject/concerto-cto": "3.23.0",
     "@accordproject/concerto-metamodel": "3.11.0",
-    "@accordproject/concerto-util": "3.20.4",
+    "@accordproject/concerto-util": "3.23.0",
     "ansi-colors": "4.1.3",
     "glob": "^7.2.3",
     "randexp": "^0.5.3",

--- a/test/data/decorate-dcs.json
+++ b/test/data/decorate-dcs.json
@@ -1,13 +1,13 @@
 {
-    "$class": "org.accordproject.decoratorcommands.DecoratorCommandSet",
+    "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
     "name": "pii",
     "version": "1.0.0",
     "commands": [
       {
-        "$class": "org.accordproject.decoratorcommands.Command",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
         "type": "UPSERT",
         "target": {
-          "$class": "org.accordproject.decoratorcommands.CommandTarget",
+          "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
           "property": "ssn"
         },
         "decorator": {
@@ -18,10 +18,10 @@
         }
       },
       {
-        "$class": "org.accordproject.decoratorcommands.Command",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
         "type": "UPSERT",
         "target": {
-          "$class": "org.accordproject.decoratorcommands.CommandTarget",
+          "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
           "property": "bar"
         },
         "decorator": {
@@ -32,10 +32,10 @@
         }
       },
       {
-        "$class": "org.accordproject.decoratorcommands.Command",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
         "type": "UPSERT",
         "target": {
-          "$class": "org.accordproject.decoratorcommands.CommandTarget",
+          "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
           "type": "concerto.metamodel@1.0.0.ObjectProperty"
         },
         "decorator": {

--- a/test/data/decorate-dcs.yaml
+++ b/test/data/decorate-dcs.yaml
@@ -1,0 +1,22 @@
+decoratorCommandsVersion: 0.4.0
+name: pii
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      property: ssn
+    decorator:
+      name: PII
+  - action: UPSERT
+    target:
+      property: bar
+    decorator:
+      name: PII
+  - action: UPSERT
+    target:
+      type: concerto.metamodel@1.0.0.ObjectProperty
+    decorator:
+      name: Hide
+      arguments:
+        - type: String
+          value: object


### PR DESCRIPTION
# Closes #74 

This PR implements CLI support for converting Decorator Command Set (DCS) files between JSON and YAML formats, addressing #74 

The implementation leverages the existing `DecoratorManager.jsonToYaml()` and `DecoratorManager.yamlToJson()` methods from `@accordproject/concerto-core` to provide format conversion capabilities directly from the command line.

### Changes Made

- **Added `convertDcs()` function** in `lib/commands.js`
  - Supports bidirectional conversion (JSON ↔ YAML)
  - Auto-detects input format based on file extension
  - Validates output file extensions
  - Creates output directories if they don't exist
  - Comprehensive error handling for edge cases

- Complete **Test** Suite
<img width="774" height="248" alt="image" src="https://github.com/user-attachments/assets/e42f1aaf-67fd-437c-b30a-9db80994719f" />


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fuyalasmit/concerto-cli:gsoc/#74`
